### PR TITLE
Fixed it so only my activities show on dashboard

### DIFF
--- a/client/src/components/Dashboard/Graphs/ActivityBubble.js
+++ b/client/src/components/Dashboard/Graphs/ActivityBubble.js
@@ -110,7 +110,7 @@ class ActivityBubble extends React.Component {
                                 autorange: true,
                                 rangeselector: selectorOptions,
                             },
-                            showlegend: true,
+                            showlegend: false,
                             margin: {
                                 l: 50,
                                 r: 50,

--- a/client/src/components/Dashboard/dashboard.js
+++ b/client/src/components/Dashboard/dashboard.js
@@ -33,6 +33,7 @@ class Dashboard extends React.Component {
     state = {
         loadingFlag: false,
         activities: [],
+        myActivities: [],
         nbrActivities: 0,
         distanceTotal: 0,
         durationTotal: 0
@@ -601,6 +602,18 @@ class Dashboard extends React.Component {
     }
     // End calulateTeamResults
 
+    async myActivitiesFilter() {
+        const activities = this.state.activities;
+        let myActivities = [];
+
+        myActivities = activities.filter (activity => {
+            if (activity.uid === this.props.user.uid) {
+                return activity;
+            }
+        });
+        this.setState({myActivities: myActivities});
+    }
+
     render() {
         // Some props take time to get ready so return null when uid not avaialble
         if (this.props.user.uid === null || this.props.user.teamUid === null) {
@@ -610,6 +623,7 @@ class Dashboard extends React.Component {
         // if the listener updated the state
         if (this.activitiesUpdated) {
             this.totals = this.calculateTotalsForTeamAndUser();
+            this.myActivitiesFilter(); 
             this.activitiesUpdated = false;
         }
 
@@ -619,6 +633,7 @@ class Dashboard extends React.Component {
         }
 
         let activities = this.state.activities;
+        let myActivities = this.state.myActivities;
 
         // header row for results
         const headerRow = 
@@ -755,7 +770,7 @@ class Dashboard extends React.Component {
                                         </span>
             
                                         {activityCardHeaderRow}
-                                        {activities.map((activity, index) => {                                         
+                                        {myActivities.map((activity, index) => {                                         
                                             return (
                                                     (index > 14) ?
                                                     ""


### PR DESCRIPTION
All I did was make it so only current user's activities show on dashboard.  Still neeed to get spinner icons which dashboard or activity page is loading AND need to setup listeners and record limits to improve performance on activity page. Maybe putting listener on server and getting from other functions.  Thats the real key I believe to making it fast.  Essentially the server can cash and only send back whats needed