### PR TITLE
Results listener react state

### DIFF
--- a/client/src/components/Auth/Session/AuthUserContext.js
+++ b/client/src/components/Auth/Session/AuthUserContext.js
@@ -5,7 +5,7 @@ const AuthUserContext = React.createContext(null);
 // This is the higher order component used in any component that needs auth / session info
 const withAuthUserContext = Component => props => (
   <AuthUserContext.Consumer>
-    {user => <Component {...props} user={user} />}
+    {context => <Component {...props} user={context} context={context} />}
   </AuthUserContext.Consumer>
 );
 

--- a/client/src/components/Auth/Session/provideAuthUserContext.js
+++ b/client/src/components/Auth/Session/provideAuthUserContext.js
@@ -47,6 +47,9 @@ const provideAuthUserContext = Component => {
                 isTeamLead: false,
                 isModerator: false,
                 isUser: false,
+
+                updatedResults: 0, 
+                results: []         // results from backend
             };
         }
 
@@ -115,12 +118,13 @@ const provideAuthUserContext = Component => {
 
                     // Listen to current challenge to get name, descirption for pages
                     if (user.challengeUid) {
-                        this.setupChallengeListener(user.challengeUid)
+                        this.setupChallengeListener(user.challengeUid);
                         ResultsAPI.getChallengeResults(user.challengeUid).then( () => {
                             // Ignore - no need to process
                         }).catch(err => {
                             console.error(`Error in provide auth user context updating challenge results on backend ${err}`)
                         });
+                        this.setupResultsListener(user.challengeUid);
                     } else {
                         this.setupChallengeListener(CHALLENGE)               
                         ResultsAPI.getChallengeResults(CHALLENGE).then( () => {
@@ -203,6 +207,85 @@ const provideAuthUserContext = Component => {
             });
         }
 
+        setupResultsListener(challengeUid) {
+            this.perf = Util.getFirestorePerf();
+    
+            console.log(`Created result listener with challengeUid: ${challengeUid}`);
+            this.perf = Util.getFirestorePerf();
+            
+            const traceFullResultsFirestore = this.perf.trace('traceFullResultsFirestore');;
+            const traceGetResultsChanges = this.perf.trace('traceGetResultsChanges');
+
+            if (this.resultslistener) {
+                this.resultslistener();
+            }
+        
+            let allDBRefs = Util.getChallengeDependentRefs(challengeUid);
+            const dbResultsRef = allDBRefs.dbResultsRef;
+
+            let ref = dbResultsRef;
+            try {
+                traceFullResultsFirestore.start();
+            } catch {
+                console.error("traceFullResultsFirestore not started ...")
+            }
+
+            let results = [];
+            this.resultslistener = ref.onSnapshot((querySnapshot) => {
+                try {
+                    traceGetResultsChanges.start();
+                } catch {
+                    console.error("traceGetResultsChanges not started ...")
+                }
+    
+                querySnapshot.docChanges().forEach(change => {
+                    if (change.type === "added") {
+                        let newResult = change.doc.data();
+                        newResult.id = change.doc.id;
+                        results.push(newResult);
+                    }
+                    if (change.type === "modified") {
+                        let changedResult = {};
+                        changedResult = change.doc.data();
+                        changedResult.id = change.doc.id;
+                        results = results.map(result => {
+                            if (changedResult.id === result.id) {
+                                return changedResult;
+                            } else {
+                                return result;
+                            }
+                        });
+                    }
+                    if (change.type === "removed") {
+                        // console.log(`Removed Result: ${change.doc.id}`);
+                        results.filter(result => {
+                            return result.id !== change.doc.id;
+                        });            
+                    }
+                });
+                this.setState({results: [...results], updatedResults: this.state.updatedResults +1});
+
+                try {
+                    traceGetResultsChanges.stop();
+                } catch {
+                    //
+                }
+
+                try {
+                    traceFullResultsFirestore.incrementMetric('nbrResults', this.results.length);
+                    traceFullResultsFirestore.stop();    
+                } catch {
+                    //
+                }
+
+                return;
+            }, (err) => {
+                console.error(`Error attaching listener: ${err}`);
+                return;
+            }); // Create listener
+        }
+    
+
         // This deletes listener to clean things up and prevent mem leaks
         componentWillUnmount() {
             this.listener();
@@ -212,6 +295,9 @@ const provideAuthUserContext = Component => {
             }
             if (this.challengeListener) {
                 this.challengeListener();
+            }
+            if (this.resultsListener) {
+                this.resultsListener();
             }
         }
 
@@ -224,6 +310,7 @@ const provideAuthUserContext = Component => {
                 <AuthUserContext.Provider value={this.state} >
                     <Component {...this.props} />
                 </AuthUserContext.Provider>
+                
             );
         }
     }

--- a/client/src/components/Dashboard/DashboardBackend.jsx
+++ b/client/src/components/Dashboard/DashboardBackend.jsx
@@ -75,7 +75,7 @@ class DashboardBackend extends React.PureComponent {
 
     // This is to render interim without waiting for all to be done.
     renderTotals(results) {
-        // console.log(`renderTotals ,teamUid:${this.props.user.teamUid} teamName:${this.props.user.teamName} uid:${this.props.user.uid} displayName:${this.props.user.displayName}`);
+        // console.log(`renderTotals ,teamUid:${this.props.context.teamUid} teamName:${this.props.context.teamName} uid:${this.props.context.uid} displayName:${this.props.context.displayName}`);
         this.setState({
             totals: results,
         });
@@ -92,22 +92,22 @@ class DashboardBackend extends React.PureComponent {
         this._mounted = true;
         let layouts = getFromLS("layouts") || {};
         this.setState({ layouts: JSON.parse(JSON.stringify(layouts)) });
-        // console.log(`this.props.user.challengeUid: ${this.props.user.challengeUid}`);
-        if (this.props.user.challengeUid) {
-            this.fetchData(this.props.user.challengeUid)
+        // console.log(`this.props.context.challengeUid: ${this.props.context.challengeUid}`);
+        if (this.props.context.challengeUid) {
+            this.fetchData(this.props.context.challengeUid)
         }
     }
 
     componentDidUpdate(prevProps) {
         // console.log(`prevProps.user.challengeUid: ${prevProps.user.challengeUid}`);
-        // console.log(`this.props.user.challengeUid: ${this.props.user.challengeUid}`);
-        if (this.props.user.challengeUid && this.props.user.challengeUid !== prevProps.user.challengeUid) {
+        // console.log(`this.props.context.challengeUid: ${this.props.context.challengeUid}`);
+        if (this.props.context.challengeUid && this.props.context.challengeUid !== prevProps.user.challengeUid) {
             if (this.resultsListener) {
                 this.resultsListener();
                 // console.log(`Detached listener`);
             }
-            // console.log(this.props.user.challengeUid)
-            this.fetchData(this.props.user.challengeUid);
+            // console.log(this.props.context.challengeUid)
+            this.fetchData(this.props.context.challengeUid);
         }
     }
     // Search for object in array based on key using uniqure ID
@@ -145,7 +145,7 @@ class DashboardBackend extends React.PureComponent {
 
         // Some need to catch up for some reason 
         // if (!this.state.totals) {
-        if (!this.props.user || !this.props.user.results) {
+        if (!this.props.context || !this.props.context.results) {
             return (<Grid container style={{ marginTop: '10px' }} justify="center"><CircularProgress /> <p>Loading ...</p> </Grid>)
         }
         // const overallResults = this.state.totals.filter(total => total.overallRecord);
@@ -182,10 +182,10 @@ class DashboardBackend extends React.PureComponent {
         });
 
         const currentOverallResults = overallResults && overallResults.length > 0 ? overallResults[0] : undefined;
-        const currentUserResults = userResults.find(result => result.uid === this.props.user.uid);
-        const currentTeamResults = teamResults.find(result => result.teamUid === this.props.user.teamUid);
+        const currentUserResults = userResults.find(result => result.uid === this.props.context.uid);
+        const currentTeamResults = teamResults.find(result => result.teamUid === this.props.context.teamUid);
 
-        if (this.props.user.uid) {
+        if (this.props.context.uid) {
             return (
                 <div style={{ backgroundColor: "#f2f2f2" }} className={classes.root}>
                     {this.state.loadingFlag ?
@@ -220,8 +220,8 @@ class DashboardBackend extends React.PureComponent {
                                 </div> : <></>}
                                 <div key="12" className={this.props.width <= 600 ? classes.mobile : null} data-grid={{ w: 4, h: 4, x: 0, y: 1, minW: 3, minH: 4, maxW: 4, maxH: 5 }}>
                                     <UserWidget
-                                        team={this.props.user.teamName}
-                                        challenge={this.props.user.challengeName}
+                                        team={this.props.context.teamName}
+                                        challenge={this.props.context.challengeName}
                                     />
                                 </div>
                                 <div key="1" className={this.props.width <= 600 ? classes.mobile : null} data-grid={{ w: 4, h: 6, x: 4, y: 1, minW: 4, minH: 6, maxW: 6 }}>
@@ -234,7 +234,7 @@ class DashboardBackend extends React.PureComponent {
                                 </div>
                                 <div key="3" className={this.props.width <= 600 ? classes.mobile : null} data-grid={{ w: 4, h: 11, x: 8, y: 1, minW: 4, minH: 6, maxW: 6 }}>
                                     <ResultsCard 
-                                        user={this.props.user} 
+                                        user={this.props.context} 
                                         challenge={this.state.challenge}
                                         teamTotals={teamResults} 
                                         userTotals={userResults} 
@@ -249,13 +249,13 @@ class DashboardBackend extends React.PureComponent {
                                 </div>
                                 <div key="5" className={this.props.width <= 600 ? classes.mobile : null} data-grid={{ w: 4, h: 8, x: 4, y: 2, minW: 3, minH: 8, maxW: 6, maxH: 9 }}>
                                     <ActivityTypeBreakdown
-                                        title={`Breakdown - ${this.props.user.displayName}`}
+                                        title={`Breakdown - ${this.props.context.displayName}`}
                                         currentTotalsShare={currentUserResults}
                                     />
                                 </div>
                                 <div key="6" className={this.props.width <= 600 ? classes.mobile : null} data-grid={{ w: 4, h: 8, x: 8, y: 2, minW: 3, minH: 8, maxW: 6, maxH: 9 }}>
                                     <ActivityTypeBreakdown
-                                        title={`Breakdown - Team ${this.props.user.teamName}`}
+                                        title={`Breakdown - Team ${this.props.context.teamName}`}
                                         currentTotalsShare={currentTeamResults}
                                     />
                                 </div>

--- a/client/src/components/Dashboard/DashboardBackend.jsx
+++ b/client/src/components/Dashboard/DashboardBackend.jsx
@@ -191,9 +191,12 @@ class DashboardBackend extends React.PureComponent {
         if (!this.props.user) {
             return (<Grid container style={{ marginTop: '10px' }} justify="center"><CircularProgress /> <p>Loading ...</p> </Grid>)
         }
-        const overallResults = this.state.totals.filter(total => total.overallRecord);
-        const teamResults = this.state.totals.filter(total => total.teamRecord);
-        const userResults = this.state.totals.filter(total => total.userRecord);
+        // const overallResults = this.state.totals.filter(total => total.overallRecord);
+        // const teamResults = this.state.totals.filter(total => total.teamRecord);
+        // const userResults = this.state.totals.filter(total => total.userRecord);
+        const overallResults = this.props.user.results.filter(total => total.overallRecord);
+        const teamResults = this.props.user.results.filter(total => total.teamRecord);
+        const userResults = this.props.user.results.filter(total => total.userRecord);
         // Sort the team and user results based on total points DESC          
         userResults.sort((a, b) => {
             const totalA = a.pointsTotal;

--- a/client/src/components/Dashboard/DashboardBackend.jsx
+++ b/client/src/components/Dashboard/DashboardBackend.jsx
@@ -133,7 +133,7 @@ class DashboardBackend extends React.PureComponent {
         this.setState({ layouts: JSON.parse(JSON.stringify(layouts)) });
         // console.log(`this.props.user.challengeUid: ${this.props.user.challengeUid}`);
         if (this.props.user.challengeUid) {
-            this.createListener(this.props.user.challengeUid)
+            // this.createListener(this.props.user.challengeUid)
             this.fetchData(this.props.user.challengeUid)
         }
     }
@@ -147,7 +147,7 @@ class DashboardBackend extends React.PureComponent {
                 // console.log(`Detached listener`);
             }
             // console.log(this.props.user.challengeUid)
-            this.createListener(this.props.user.challengeUid);
+            // this.createListener(this.props.user.challengeUid);
             this.fetchData(this.props.user.challengeUid);
         }
     }
@@ -185,18 +185,16 @@ class DashboardBackend extends React.PureComponent {
         const { classes } = this.props;
 
         // Some need to catch up for some reason 
-        if (!this.state.totals) {
-            return (<Grid container style={{ marginTop: '10px' }} justify="center"><CircularProgress /> <p>Loading ...</p> </Grid>)
-        }
-        if (!this.props.user) {
+        // if (!this.state.totals) {
+        if (!this.props.user || !this.props.user.results) {
             return (<Grid container style={{ marginTop: '10px' }} justify="center"><CircularProgress /> <p>Loading ...</p> </Grid>)
         }
         // const overallResults = this.state.totals.filter(total => total.overallRecord);
         // const teamResults = this.state.totals.filter(total => total.teamRecord);
         // const userResults = this.state.totals.filter(total => total.userRecord);
-        const overallResults = this.props.user.results.filter(total => total.overallRecord);
-        const teamResults = this.props.user.results.filter(total => total.teamRecord);
-        const userResults = this.props.user.results.filter(total => total.userRecord);
+        const overallResults = this.props.context.results.filter(total => total.overallRecord);
+        const teamResults = this.props.context.results.filter(total => total.teamRecord);
+        const userResults = this.props.context.results.filter(total => total.userRecord);
         // Sort the team and user results based on total points DESC          
         userResults.sort((a, b) => {
             const totalA = a.pointsTotal;
@@ -223,8 +221,6 @@ class DashboardBackend extends React.PureComponent {
             }
             return comparison * -1;  // Invert so it will sort in descending order
         });
-            
-        
 
         const currentOverallResults = overallResults && overallResults.length > 0 ? overallResults[0] : undefined;
         const currentUserResults = userResults.find(result => result.uid === this.props.user.uid);
@@ -258,6 +254,7 @@ class DashboardBackend extends React.PureComponent {
                                         start={this.state.challenge.startCity}
                                         end={this.state.challenge.endCity}
                                         waypoints={this.state.challenge.waypoints}
+                                        updatedResults={this.props.context.updatedResults}
                                         results={userResults}
                                         endDate={this.state.challenge.endDate}
                                         callbackParent={() => this.onChildChanged()} />

--- a/client/src/components/Dashboard/DashboardBackend.jsx
+++ b/client/src/components/Dashboard/DashboardBackend.jsx
@@ -73,45 +73,6 @@ class DashboardBackend extends React.PureComponent {
         this.setState({ layouts });
     }
 
-    createListener(challengeUid) {
-        // This is just to show something on the page while its loading
-        this.setState({loadingFlag: true});
-        this.renderTotals(this.state.totals);    
-        const traceFullRetrieval = this.perf.trace('traceFullRetrievalFirestore');
-        try {
-            traceFullRetrieval.start();
-        } catch {
-            console.error("traceFullRetrieval not started ...")
-        }
-
-        let traceFullRetrievalT1 = new Date();
-
-        ResultsListener.createResultsListener(challengeUid).then( results => {
-            try {
-                traceFullRetrieval.incrementMetric('nbrResults', results.length);
-                traceFullRetrieval.stop();
-            } catch {
-                //
-            }
-
-            let traceFullRetrievalT2 = new Date();
-            let traceFullRetrievalDiff = traceFullRetrievalT2.getTime() - traceFullRetrievalT1.getTime();
-            console.log(`traceFullRetrievalDiff time is milliseconds: ${traceFullRetrievalDiff}`);
-    
-            this.renderTotals(results);
-
-            this.setState({loadingFlag: false});
-        }).catch( err => {
-            try {
-                traceFullRetrieval.stop();
-            } catch {
-                //
-            }
-
-            console.error(`Error attaching listener: ${err}`);
-            this.setState({loadingFlag: false});
-        });
-    }
     // This is to render interim without waiting for all to be done.
     renderTotals(results) {
         // console.log(`renderTotals ,teamUid:${this.props.user.teamUid} teamName:${this.props.user.teamName} uid:${this.props.user.uid} displayName:${this.props.user.displayName}`);
@@ -133,7 +94,6 @@ class DashboardBackend extends React.PureComponent {
         this.setState({ layouts: JSON.parse(JSON.stringify(layouts)) });
         // console.log(`this.props.user.challengeUid: ${this.props.user.challengeUid}`);
         if (this.props.user.challengeUid) {
-            // this.createListener(this.props.user.challengeUid)
             this.fetchData(this.props.user.challengeUid)
         }
     }
@@ -147,7 +107,6 @@ class DashboardBackend extends React.PureComponent {
                 // console.log(`Detached listener`);
             }
             // console.log(this.props.user.challengeUid)
-            // this.createListener(this.props.user.challengeUid);
             this.fetchData(this.props.user.challengeUid);
         }
     }

--- a/client/src/components/Dashboard/GoogleMap/GoogleMapUser.js
+++ b/client/src/components/Dashboard/GoogleMap/GoogleMapUser.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import MapUser from './MapUser'
 //import { Card, CardContent, Grid, Box, Typography, Table, TableHead, TableRow, TableCell, TableBody } from '@material-ui/core';
 import { Card, CardContent, Grid, Box, Typography } from '@material-ui/core';
@@ -67,9 +67,10 @@ const GoogleMapUser = (props) => {
     // TODO :- Right now the function state values are not displayed on the dashboard
     // unless you go into the debugger.  It must be a timing issuie with state vars but
     // I have yet to figure it out
-    const calcNextLegInfo = (legs) => {
+    const calcNextLegInfo = (legs, newResults) => {
+        let newLegTotals  = newResults;
         //Loop through each result - either by team or User
-        for (let k = 0; k < legTotals.length; k++) {
+        for (let k = 0; k < newLegTotals.length; k++) {
             let totalDistanceToNextLeg = 0;
             let nextLegName = "";
             let distanceToNextLeg = 0;
@@ -81,10 +82,10 @@ const GoogleMapUser = (props) => {
             // Loop until you find the next leg based on your distance
             // This loop will end where you are "in between" two legs
             // Then you just need to extract the leg info an attach to result record
-            includedDistanceTotal += props.challenge.isSwim ? legTotals[k].swimPointsTotal : 0;
-            includedDistanceTotal += props.challenge.isBike ? legTotals[k].bikeDistanceTotal : 0;
-            includedDistanceTotal += props.challenge.isRun ? legTotals[k].runPointsTotal : 0;
-            includedDistanceTotal += props.challenge.isOther ? legTotals[k].otherDistanceTotal : 0;
+            includedDistanceTotal += props.challenge.isSwim ? newLegTotals[k].swimPointsTotal : 0;
+            includedDistanceTotal += props.challenge.isBike ? newLegTotals[k].bikeDistanceTotal : 0;
+            includedDistanceTotal += props.challenge.isRun ? newLegTotals[k].runPointsTotal : 0;
+            includedDistanceTotal += props.challenge.isOther ? newLegTotals[k].otherDistanceTotal : 0;
 
             for (i = 0; i < legs.length && totalDistanceToNextLeg < includedDistanceTotal ; i++) {
                 let legDistance = legs[i].distance.value / 1000 / 1.609344;  // to miles
@@ -103,13 +104,13 @@ const GoogleMapUser = (props) => {
                 nextLegCompletionPercent = parseInt((includedDistanceTotal / totalDistanceToNextLeg)  * 100);
             }
 
-            legTotals[k].nextLegName = nextLegName;
-            legTotals[k].distanceToNextLeg = distanceToNextLeg.toFixed(0).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-            legTotals[k].nextLegCompletionPercent = nextLegCompletionPercent;
-            legTotals[k].includedDistanceTotal = includedDistanceTotal;
-            legTotals[k].includedDistanceTotalDisplay = includedDistanceTotal.toFixed(0).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+            newLegTotals[k].nextLegName = nextLegName;
+            newLegTotals[k].distanceToNextLeg = distanceToNextLeg.toFixed(0).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+            newLegTotals[k].nextLegCompletionPercent = nextLegCompletionPercent;
+            newLegTotals[k].includedDistanceTotal = includedDistanceTotal;
+            newLegTotals[k].includedDistanceTotalDisplay = includedDistanceTotal.toFixed(0).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
         }
-        setLegTotals(legTotals);
+        setLegTotals(newLegTotals);
 
     }
 
@@ -126,6 +127,8 @@ const GoogleMapUser = (props) => {
     if (props.challenge.isOther) {
         challengeMapIncludes += "Other "
     }
+    console.log(`updatedResults: ${props.updatedResults}`);
+
     return (
         <Card style={{ height: '100%' }}>
             <CardContent style={{ height: '100%' }} >
@@ -145,6 +148,7 @@ const GoogleMapUser = (props) => {
                             }}
                             challenge={props.challenge}
                             results={props.results}
+                            updatedResults={props.updatedResults}
                             start={props.start}
                             end={props.end}
                             waypoints={props.waypoints}

--- a/client/src/components/Dashboard/GoogleMap/MapUser.js
+++ b/client/src/components/Dashboard/GoogleMap/MapUser.js
@@ -82,14 +82,14 @@ class Map extends Component {
 
                 // calc next leg info calls the parent to attach the next leg info
                 // to each of the result records
-                this.props.calcNextLegInfo(response.routes[0].legs);
+                this.props.calcNextLegInfo(response.routes[0].legs, this.props.results);
                 this.props.computeTotalDistance(response);
-                this.props.results.forEach(total => {
+                this.props.results.forEach(result => {
                     let includedDistanceTotal = 0;
-                    includedDistanceTotal += this.props.challenge.isSwim ? total.swimPointsTotal : 0;
-                    includedDistanceTotal += this.props.challenge.isBike ? total.bikeDistanceTotal : 0;
-                    includedDistanceTotal += this.props.challenge.isRun ? total.runPointsTotal : 0;
-                    this.putMarkerOnRoute(polyline, includedDistanceTotal, total.userRecord ? total.displayName : total.teamName);
+                    includedDistanceTotal += this.props.challenge.isSwim ? result.swimPointsTotal : 0;
+                    includedDistanceTotal += this.props.challenge.isBike ? result.bikeDistanceTotal : 0;
+                    includedDistanceTotal += this.props.challenge.isRun ? result.runPointsTotal : 0;
+                    this.putMarkerOnRoute(polyline, includedDistanceTotal, result.userRecord ? result.displayName : result.teamName);
                 });
             } else {
                 alert("directions response " + status);
@@ -176,6 +176,25 @@ class Map extends Component {
             })
         } else {
             this.onScriptLoad()
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.updatedResults && this.props.updatedResults !== prevProps.updatedResults) {
+            if (!window.google) {
+                var s = document.createElement('script');
+                s.type = 'text/javascript';
+                s.src = `https://maps.googleapis.com/maps/api/js?key=${FB_CONFIG.API_KEY}&libraries=places`
+                var x = document.getElementsByTagName('script')[0];
+                x.parentNode.insertBefore(s, x);
+                // Below is important. 
+                //We cannot access google.maps until it's finished loading
+                s.addEventListener('load', e => {
+                    this.onScriptLoad()
+                })
+            } else {
+                this.onScriptLoad()
+            }
         }
     }
 

--- a/client/src/components/Dashboard/ResultsCard/ResultsCard.jsx
+++ b/client/src/components/Dashboard/ResultsCard/ResultsCard.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import Box from '@material-ui/core/Box';
-import { Link } from "react-router-dom";
+// import { Link } from "react-router-dom";
 import LaunchIcon from '@material-ui/icons/Launch';
 import './Result.css'
 import { Table, TableHead, TableBody, TableCell, TableRow, Card, CardContent, Tooltip } from '@material-ui/core';
@@ -37,14 +37,19 @@ const ResultsCard = (props) => {
 
     const leaderboardTitleRow =
         <Box className="row" fontStyle="oblique" fontWeight="fontWeightBold">
-            <Link style={{ textDecoration: "none", color: "grey" }}
-                to={{
-                    pathname: "/activities",
-                    state: {
-                        filterByString: "Mine"
-                    }
-                }}>{onlyTeams ? "Team Leaderboard" : "Individual Leaders"}
-            </Link>
+            {onlyTeams ? 
+                <Tooltip title="Show Results">
+                    <span onClick={handleClickTeamResults}>
+                        Team Leaderboard 
+                    </span>
+                </Tooltip>
+                :
+                <Tooltip title="Show Results">
+                    <span onClick={handleClickUserResults}>
+                        Individual Leaders
+                    </span>
+                </Tooltip>
+            }
             <div style={{ float: 'right' }}>
                 {onlyTeams ? 
                     <Tooltip title="Show Results">


### PR DESCRIPTION
- Got dashboard listener into react state working
- Made sure all items updated in realtime on dshboard
- removed listener code from dashboard and just get from props
- added "context" to replace "user" from react context since user no longer makes sense.  I will phase it out so props.user and prop.context pass the same thing for now but we need to start using context so eventually we can ditch user.
- fixed link on leaderboard text so it goes to popup results vs activities